### PR TITLE
Single copter - fix buzzing servos 

### DIFF
--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -16,7 +16,7 @@
 #define NUM_ACTUATORS 4
 
 #define AP_MOTORS_SINGLE_SPEED_DIGITAL_SERVOS 250 // update rate for digital servos
-#define AP_MOTORS_SINGLE_SPEED_ANALOG_SERVOS 125  // update rate for analog servos
+#define AP_MOTORS_SINGLE_SPEED_ANALOG_SERVOS 50  // update rate for analog servos
 
 #define AP_MOTORS_SINGLE_SERVO_INPUT_RANGE      4500    // roll or pitch input of -4500 will cause servos to their minimum (i.e. radio_min), +4500 will move them to their maximum (i.e. radio_max)
 


### PR DESCRIPTION
Control flap servos buzzing on single copter prototype. The update rate for analog servos changed from 125 to 50 Hertz. 
